### PR TITLE
Add Node migration tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,32 @@ The script supports two runtime flags, with flags needing to come after your use
 
 Asset URLs are not automatically replaced in any source code, mostly because that's much harder than you'd think it'd be, so you will still need to replace CDN URLs in your code with relative links to the `./glitch-assets` folder that all your project's assets were downloaded into.
 
+If you prefer, you can run the `migrate.mjs` script included in this repository. It uploads all assets in `.glitch-assets` to your Cloudflare R2 bucket and then rewrites every reference to the old CDN URLs in your project files with the new URLs.
+
+### Using migrate.mjs
+
+1. Install the required packages:
+
+   ```bash
+   npm install @aws-sdk/client-s3 node-fetch dotenv
+   ```
+
+2. Create a `.env` file in the same folder as `migrate.mjs` and set these variables:
+
+   ```
+   R2_ACCESS_KEY_ID=your-access-key
+   R2_SECRET_ACCESS_KEY=your-secret-key
+   R2_ACCOUNT_ID=your-account-id
+   R2_BUCKET_NAME=your-bucket
+   R2_PUBLIC_URL=https://your-public-bucket-url
+   ```
+
+3. Run the script from your project directory:
+
+   ```bash
+   node migrate.mjs
+   ```
+
 ---
 
 ## Known issues

--- a/migrate.mjs
+++ b/migrate.mjs
@@ -1,0 +1,110 @@
+#!/usr/bin/env node
+import fs from 'fs';
+import path from 'path';
+import { S3Client, PutObjectCommand } from '@aws-sdk/client-s3';
+import fetch from 'node-fetch';
+import dotenv from 'dotenv';
+
+dotenv.config();
+
+const {
+  R2_ACCESS_KEY_ID,
+  R2_SECRET_ACCESS_KEY,
+  R2_ACCOUNT_ID,
+  R2_BUCKET_NAME,
+  R2_PUBLIC_URL
+} = process.env;
+
+if (!R2_ACCESS_KEY_ID || !R2_SECRET_ACCESS_KEY || !R2_ACCOUNT_ID || !R2_BUCKET_NAME) {
+  console.error('R2 credentials are missing in environment variables');
+  process.exit(1);
+}
+
+const endpoint = `https://${R2_ACCOUNT_ID}.r2.cloudflarestorage.com`;
+
+const s3 = new S3Client({
+  region: 'auto',
+  endpoint,
+  credentials: {
+    accessKeyId: R2_ACCESS_KEY_ID,
+    secretAccessKey: R2_SECRET_ACCESS_KEY,
+  },
+});
+
+async function upload(filename, data, contentType) {
+  const command = new PutObjectCommand({
+    Bucket: R2_BUCKET_NAME,
+    Key: filename,
+    Body: data,
+    ContentType: contentType,
+  });
+  await s3.send(command);
+}
+
+async function download(url) {
+  const res = await fetch(url);
+  if (!res.ok) {
+    throw new Error(`Failed to download ${url}: ${res.statusText}`);
+  }
+  const buffer = await res.buffer();
+  const contentType = res.headers.get('content-type') || undefined;
+  return { buffer, contentType };
+}
+
+async function processAsset(asset) {
+  const parsed = new URL(asset.url);
+  const filename = decodeURIComponent(path.basename(parsed.pathname));
+  const { buffer, contentType } = await download(asset.url);
+  await upload(filename, buffer, contentType);
+  return { oldUrl: asset.url, newUrl: `${R2_PUBLIC_URL}/${filename}` };
+}
+
+async function migrate() {
+  const lines = fs.existsSync('.glitch-assets')
+    ? fs.readFileSync('.glitch-assets', 'utf8').split('\n').filter(Boolean)
+    : [];
+  const assets = lines
+    .map((l) => JSON.parse(l))
+    .filter((a) => a.url && a.url.includes('cdn.glitch.global'));
+
+  const map = {};
+  for (const asset of assets) {
+    if (map[asset.url]) continue;
+    try {
+      const { newUrl } = await processAsset(asset);
+      map[asset.url] = newUrl;
+      console.log(`${asset.url} -> ${newUrl}`);
+    } catch (err) {
+      console.error(err.message);
+    }
+  }
+
+  const files = [];
+  function walk(dir) {
+    for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+      if (entry.name === 'node_modules' || entry.name === '.git') continue;
+      const p = path.join(dir, entry.name);
+      if (entry.isDirectory()) walk(p);
+      else files.push(p);
+    }
+  }
+  walk('.');
+
+  for (const f of files) {
+    let data = fs.readFileSync(f, 'utf8');
+    let changed = false;
+    for (const [oldUrl, newUrl] of Object.entries(map)) {
+      if (data.includes(oldUrl)) {
+        data = data.split(oldUrl).join(newUrl);
+        changed = true;
+      }
+    }
+    if (changed) fs.writeFileSync(f, data, 'utf8');
+  }
+}
+
+migrate().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});
+


### PR DESCRIPTION
## Summary
- add `migrate.mjs` for uploading assets to R2 and rewriting CDN URLs
- document the migration script in the README
- add instructions on how to use `migrate.mjs`

## Testing
- `git log -1 --stat`


------
https://chatgpt.com/codex/tasks/task_e_68510ea51fdc8326bf025cbb15dd77cb